### PR TITLE
Fixed face cropping

### DIFF
--- a/app/src/main/java/com/darkbyte/groupit/facedetection/Utils.kt
+++ b/app/src/main/java/com/darkbyte/groupit/facedetection/Utils.kt
@@ -54,7 +54,8 @@ object Utils {
 
     fun initiateTFLite(context: Context, assetManager: AssetManager) {
         try {
-            detector = TFLiteObjectDetectionAPIModel().create(
+            detector = TFLiteObjectDetectionAPIModel( context ).create(
+                context ,
                 assetManager,
                 TF_OD_API_MODEL_FILE,
                 TF_OD_API_LABELS_FILE,
@@ -130,16 +131,16 @@ object Utils {
             val croppedFaceBitmap = Bitmap.createBitmap(
                 mutableBitmap!!,
                 bounds.left,
-                minOf(bounds.top, 0),
-                if (bounds.left + bounds.width() <= bounds.width()) {
+                maxOf(bounds.top, 0),
+                if (bounds.left + bounds.width() <= mutableBitmap.width) {
                     bounds.width()
                 } else {
                     mutableBitmap.width - bounds.left
                 },
-                if (bounds.top + bounds.height() <= bounds.height()) {
+                if (bounds.top + bounds.height() <= mutableBitmap.height) {
                     bounds.height()
                 } else {
-                    mutableBitmap.height - minOf(bounds.top, 0)
+                    mutableBitmap.height - maxOf(bounds.top, 0)
                 }
             )
             val result = detector!!.recognizeImage(croppedFaceBitmap)

--- a/app/src/main/java/com/darkbyte/groupit/tflite/TFLiteObjectDetectionAPIModel.kt
+++ b/app/src/main/java/com/darkbyte/groupit/tflite/TFLiteObjectDetectionAPIModel.kt
@@ -1,5 +1,6 @@
 package com.darkbyte.groupit.tflite
 
+import android.content.Context
 import android.content.res.AssetFileDescriptor
 import android.content.res.AssetManager
 import android.graphics.Bitmap
@@ -9,7 +10,9 @@ import android.util.Pair
 import com.darkbyte.groupit.logger.Logger
 import org.tensorflow.lite.Interpreter
 import java.io.BufferedReader
+import java.io.File
 import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -33,7 +36,7 @@ private const val IMAGE_STD = 128.0f
 // Number of threads in the java app
 private const val NUM_THREADS = 4
 
-class TFLiteObjectDetectionAPIModel : SimilarityClassifier {
+class TFLiteObjectDetectionAPIModel( private val context: Context ) : SimilarityClassifier {
 
     var embeddings: Array<FloatArray> = arrayOf(floatArrayOf())
     private var isModelQuantized = false
@@ -78,6 +81,8 @@ class TFLiteObjectDetectionAPIModel : SimilarityClassifier {
     ): UserFace? {
 
         if (bitmap == null) return null
+
+        saveBitmap( context , bitmap , "sample" )
         val size = maxOf(bitmap.width * bitmap.height, inputSize * inputSize)
         val pixels = IntArray(size)
         imgData.rewind()
@@ -178,6 +183,11 @@ class TFLiteObjectDetectionAPIModel : SimilarityClassifier {
         return ret
     }
 
+    private fun saveBitmap(context: Context, image: Bitmap, name: String) {
+        val fileOutputStream = FileOutputStream(File( context.filesDir.absolutePath + "/$name.png"))
+        image.compress(Bitmap.CompressFormat.PNG, 100, fileOutputStream)
+    }
+
 
     /** Memory-map the model file in Assets.  */
     @Throws(IOException::class)
@@ -201,13 +211,14 @@ class TFLiteObjectDetectionAPIModel : SimilarityClassifier {
      */
     @Throws(IOException::class)
     fun create(
+        context: Context ,
         assetManager: AssetManager,
         modelFilename: String,
         labelFilename: String,
         inputSize: Int,
         isQuantized: Boolean
     ): SimilarityClassifier {
-        val tflModel = TFLiteObjectDetectionAPIModel()
+        val tflModel = TFLiteObjectDetectionAPIModel( context )
         val actualFilename = labelFilename.split("file:///android_asset/".toRegex())
             .dropLastWhile { it.isEmpty() }
             .toTypedArray()[1]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.0-alpha16"
+agp = "8.2.0"
 exifinterface = "1.3.6"
 faceDetection = "16.1.5"
 kotlin = "1.9.0"


### PR DESCRIPTION
There is a problem with the face cropping logic. The FaceNet model needs only cropped faces, but the current code was supplying the entire image or a part of it to the model, which would result in incorrect face vector generation.
I have tried fixing the code in `Utils.kt` and added `saveBitmap` method in `TFLiteObjectDetectionModel.kt` to save the cropped bitmap in the app's internal storage so that it can be checked.